### PR TITLE
Fix theme handling in ProseContent component

### DIFF
--- a/app/components/ProseContent.tsx
+++ b/app/components/ProseContent.tsx
@@ -9,14 +9,16 @@ interface ProseContentProps {
 }
 
 const ProseContent: FC<ProseContentProps> = ({ contentHtml, className = '' }) => {
-  const { theme } = useTheme();
+  const { theme, systemTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  const proseClass = !mounted ? 'prose prose-invert' : (theme === 'dark' ? 'prose prose-invert' : 'prose');
+  // Default to dark mode when not mounted; handle 'system' theme if needed.
+  const currentTheme = !mounted ? 'dark' : (theme === 'system' ? systemTheme : theme);
+  const proseClass = currentTheme === 'dark' ? 'prose prose-invert' : 'prose';
 
   return (
     <div


### PR DESCRIPTION
Enhance theme handling to support system theme and default to dark mode when the component is not mounted.